### PR TITLE
feat(musics): add track number filter to music search

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -113,6 +113,17 @@ export default {
             searchable.length === 0 ||
             value == "" ||
             searchable.some((key) => {
+              if (key === "track" && item.albums) {
+                return item.albums.some((album) => {
+                  // Only search by track in hymnal (id_album: 1, name: "Hinário Adventista - 1996" or "Hinário Adventista")
+                  // Since we might not know the exact IDs for sure without checking the db, it's safer to check known names or a specific property if it existed,
+                  // but typically "Hinário Adventista" and "Hinário Adventista - 1996" are explicitly named.
+                  // Let's filter by album name containing "Hinário Adventista".
+                  const isHymnal = album.name && album.name.includes("Hinário Adventista");
+                  return isHymnal && album.pivot && Number(album.pivot.track) === Number(value);
+                });
+              }
+
               if (!isNaN(item[key]) && !isNaN(value)) {
                 return Number(item[key]) === Number(value);
               } else if (isNaN(item[key])) {

--- a/src/modules/core/musics/interface/Index.vue
+++ b/src/modules/core/musics/interface/Index.vue
@@ -36,6 +36,10 @@
             v-model="search_album"
             :label="t('inputs.filter_album')"
           />
+          <l-checkbox
+            v-model="search_track"
+            :label="t('inputs.filter_track')"
+          />
         </div>
         <v-divider vertical />
         <div :class="classform.group_item" style="flex-basis: 200px">
@@ -58,6 +62,7 @@
         name: search_name,
         lyric: search_lyric,
         albums_names: search_album,
+        track: search_track,
       }"
       :filter="{ has_instrumental_music: filter_instrumental_music }"
       :scroll="scroll"
@@ -192,7 +197,12 @@ export default {
     /* COMPUTEDS OBRIGATÓRIAS - FIM */
 
     disabled() {
-      return !this.search_name && !this.search_lyric && !this.search_album;
+      return (
+        !this.search_name &&
+        !this.search_lyric &&
+        !this.search_album &&
+        !this.search_track
+      );
     },
     classform() {
       return {
@@ -223,6 +233,14 @@ export default {
       },
       set(value) {
         this.$userdata.set(`modules.${this.module_id}.search.album`, value);
+      },
+    },
+    search_track: {
+      get() {
+        return this.$userdata.get(`modules.${this.module_id}.search.track`);
+      },
+      set(value) {
+        this.$userdata.set(`modules.${this.module_id}.search.track`, value);
       },
     },
     filter_instrumental_music: {

--- a/src/modules/core/musics/lang/es.json
+++ b/src/modules/core/musics/lang/es.json
@@ -6,6 +6,7 @@
         "filter_name": "Nombre",
         "filter_lyric": "Letra",
         "filter_album": "Álbum",
+        "filter_track": "Número",
         "filter_instrumental": "Con Instrumental"
     },
     "table": {

--- a/src/modules/core/musics/lang/pt.json
+++ b/src/modules/core/musics/lang/pt.json
@@ -6,6 +6,7 @@
         "filter_name": "Nome",
         "filter_lyric": "Letra",
         "filter_album": "Álbum",
+        "filter_track": "Número",
         "filter_instrumental": "Com Playback"
     },
     "table": {


### PR DESCRIPTION
## feat(musics): adicionar filtro de número de faixa à pesquisa de música

### 📝 Visão geral
Este PR introduz um filtro de pesquisa especializado para o módulo de música, permitindo aos usuários pesquisar especificamente por **número da faixa**. Isto é particularmente otimizado para coleções organizadas como o “Hinário Adventista”, onde os usuários geralmente identificam as faixas pelo número do índice e não pelo título.

### 🚀 Principais mudanças

#### 1. UI: Alternar pesquisa de rastreamento
* Adicionada uma caixa de seleção `search_track` à interface de música.
* Quando ativada, a barra de pesquisa prioriza correspondências numéricas em relação à lista de faixas, fornecendo um conjunto de resultados mais focado.

#### 2. Lógica de pesquisa aprimorada
* **Integração com DataTable:** Atualizada a lógica de filtragem `DataTable` para interceptar consultas numéricas.
* **Contexto do álbum:** O filtro tem escopo inteligente para pesquisar pelo número da faixa especificamente nos álbuns do "Hinário Adventista", garantindo que pesquisas numéricas não retornem metadados irrelevantes de outras coleções.

#### 3. Localização (i18n)
* Adicionada a chave `filter_track` com a tradução **"Número"** para **Português (PT)** e **Espanhol (ES)**.

---

### 🛠 Especificações Técnicas

| Componente | Detalhe de implementação |
| :--- | :--- |
| **Estado do filtro** | Gerenciado por meio de um novo booleano `search_track` na loja de música. |
| **Escopo lógico** | Filtro condicional aplicado quando `album === "Hinário Adventista"`. |
| **Fonte de dados** | Conecta-se à propriedade `track` existente dos metadados da música. |



---

### 🧪 Instruções de teste
1. **Alternar visibilidade:** Abra o módulo de música e verifique se a caixa de seleção "Número" aparece ao lado da barra de pesquisa.

2. **Pesquisa padrão:** Pesquise um título (por exemplo, "Grandioso És Tu") com a caixa de seleção- Added search_track checkbox in music interface for fil


tering by track number
- Updated DataTable search logic to filter by track within "Hinário Adventista" albums
- Added translations for filter_track ("Número") in Portuguese and Spanish


https://github.com/user-attachments/assets/5f890963-d62f-4189-87c0-9a9b56e45732