### PR TITLE
fix(#42): remove state mutation from Vuex getter 'exists'

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -22,13 +22,12 @@ export default {
     const keys = data.split(".");
     let current = state;
 
-    for (let i = 0; i < keys.length - 1; i++) {
-      const key = keys[i];
-      if (!current[key]) {
-        current[key] = {};
+    for (let i = 0; i < keys.length; i++) {
+      if (current === null || current === undefined || !(keys[i] in current)) {
+        return false;
       }
-      current = current[key];
+      current = current[keys[i]];
     }
-    return current[keys[keys.length - 1]] !== undefined;
+    return current !== undefined;
   },
 };


### PR DESCRIPTION
## Problem

The `exists` getter in `src/store/getters.js` was **mutating store state** when checking nested paths. When a path like `modules.musics.search` was queried and intermediate keys didn't exist, the getter created empty objects (`current[key] = {}`) as a side effect.

Getters must be pure read-only functions. Mutating state from a getter violates Vuex principles and can cause infinite re-render loops.

## Fix

- Iterate all keys including the last one
- Return `false` immediately if any path segment doesn't exist (using `in` operator)
- No more `current[key] = {}` side effects

## Build

All builds pass. Minimal change — 1 file, 5 insertions, 6 deletions.

Fixes #42