### PR TITLE
perf(#47): skip postMessage when value hasn't changed

### DIFF
--- a/src/helpers/AppData.js
+++ b/src/helpers/AppData.js
@@ -2,7 +2,20 @@ import store from "@/store";
 
 export default {
   set(param, value) {
+    const oldValue = this.get(param);
+
     store.commit("setData", [param, value]);
+
+    if (
+      typeof oldValue === "object" &&
+      oldValue !== null &&
+      JSON.stringify(oldValue) === JSON.stringify(value)
+    ) {
+      return;
+    }
+    if (oldValue === value) {
+      return;
+    }
 
     const popup = this.get("popup");
     if (
@@ -13,7 +26,6 @@ export default {
     ) {
       if (popup.closed) {
         this.set("popup", null);
-        //this.set("popup_module", null);
       } else {
         try {
           popup.postMessage({ param, value }, window.location.origin);


### PR DESCRIPTION
## Problem

`AppData.set()` was sending `postMessage` to the popup window on **every single call**, even when the new value was identical to the old one. This caused unnecessary IPC overhead on every state mutation.

## Fix

- Read the old value before committing to store
- Skip `postMessage` if the value hasn't changed
- Shallow compare (`===`) for primitives, `JSON.stringify` compare for objects
- Remove commented-out dead code

## Build

All builds pass. 1 file changed, 13 insertions, 1 deletion.

Fixes #47