### PR TITLE
fix(#45): remove installRemoteModule referencing non-existent methods

### DIFF
--- a/src/helpers/ModuleManager.js
+++ b/src/helpers/ModuleManager.js
@@ -113,31 +113,6 @@ export default {
     }
   },
 
-  // Remote module installation method
-  async installRemoteModule(moduleId) {
-    try {
-      // Fetch module manifest from remote module store
-      const manifest = await this.fetchModuleManifest(moduleId);
-
-      // Download module module dynamically
-      const ModuleClass = await this.downloadModuleModule(manifest);
-
-      // Create module instance
-      const moduleInstance = new ModuleClass();
-
-      // Register and install module
-      if (this.register(moduleId, moduleInstance)) {
-        await this.installModule(moduleInstance);
-        return moduleInstance;
-      }
-
-      return null;
-    } catch (error) {
-      console.error("Remote module installation failed:", error);
-      throw error;
-    }
-  },
-
   async init(i18n) {
     this.i18n = i18n;
 
@@ -163,13 +138,5 @@ export default {
 
     //Importa as interfaces dos modules
     $appdata.set("import_modules", true);
-
-    // Optional: Remote module installation
-    try {
-      // Uncomment and modify as needed
-      // await ModuleManager.installRemoteModule('some-module-id');
-    } catch (error) {
-      console.error("Failed to install remote module", error);
-    }
   },
 };


### PR DESCRIPTION
## Problem

`installRemoteModule()` in `src/helpers/ModuleManager.js` called `this.fetchModuleManifest()` and `this.downloadModuleModule()` — methods that **do not exist** anywhere in the codebase. If ever invoked, it would crash with `TypeError: this.fetchModuleManifest is not a function`.

It was never called at runtime (the call in `init()` was commented out), making it dead code.

## Fix

- Remove `installRemoteModule()` method entirely
- Remove dead `try/catch` block in `init()` that referenced it
- When remote module support is needed, it should be implemented from scratch with actual fetch/download logic

## Build

All builds pass. 1 file changed, 33 deletions (net negative = less code to maintain).

Fixes #45